### PR TITLE
feat: 增加兼容 Docker 环境的 tmux 启动脚本，解决无 GUI 环境下的多终端运行问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ colcon build --symlink-install
 构建好工程之后，然后启动文件
 
 ```bash
-bash start.sh
+bash start.sh 
+# 或者在docker环境内使用tmux
+# bash tmuxstart.sh 
 ```
 
 ![image.png](picture/image%201.png)

--- a/tmuxstart.sh
+++ b/tmuxstart.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# 获取脚本所在目录的绝对路径
+WORKSPACE_ROOT=$(cd "$(dirname "$0")"; pwd)
+INSTALL_SETUP="$WORKSPACE_ROOT/install/setup.bash"
+
+# 检查环境文件是否存在
+if [ ! -f "$INSTALL_SETUP" ]; then
+    echo "错误: 找不到 $INSTALL_SETUP"
+    echo "请先在 $WORKSPACE_ROOT 运行: colcon build --symlink-install"
+    exit 1
+fi
+
+SESSION="simdog"
+
+# 清理旧会话
+tmux kill-session -t $SESSION 2>/dev/null
+
+# 启动第一个任务：Gazebo
+tmux new-session -d -s $SESSION -n "gazebo" "source $INSTALL_SETUP && ros2 launch go2_config gazebo_velodyne.launch.py rviz:=false; exec bash"
+
+echo "正在启动 Gazebo，等待 8 秒..."
+sleep 8
+
+# 启动其他模块
+tmux new-window -t $SESSION -n "lio_sam" "source $INSTALL_SETUP && ros2 launch lio_sam lidar.launch.py; exec bash"
+tmux new-window -t $SESSION -n "ndt"     "source $INSTALL_SETUP && ros2 launch ndt_relocalization ndt_localization.launch.py; exec bash"
+tmux new-window -t $SESSION -n "teleop"  "source $INSTALL_SETUP && ros2 run teleop_twist_keyboard teleop_twist_keyboard; exec bash"
+
+# 切换到键盘控制窗口并进入
+tmux select-window -t $SESSION:teleop
+tmux attach-session -t $SESSION


### PR DESCRIPTION
Description:
问题背景：
原 start.sh 使用 gnome-terminal 弹出新窗口，这在 Docker 容器及通过 SSH 连接的开发板（如嵌入式机器人端）上无法使用。

解决方案：
引入 tmuxstart.sh。通过 tmux 终端复用技术，在单个终端会话内管理多个 ROS 2 任务：

Window 0: Gazebo 仿真环境

Window 1: LIO-SAM SLAM

Window 2: NDT 定位模块

Window 3: 键盘控制 (Teleop)